### PR TITLE
Fix IndexOutOfBoundsException in LinkCommentsPresenter

### DIFF
--- a/app/src/main/java/com/ddiehl/android/htn/listings/comments/LinkCommentsPresenter.java
+++ b/app/src/main/java/com/ddiehl/android/htn/listings/comments/LinkCommentsPresenter.java
@@ -149,20 +149,34 @@ public class LinkCommentsPresenter extends BaseListingsPresenter {
     }
 
     private void onLoadMoreChildren(MoreChildrenResponse response, @NonNull CommentStub parentStub) {
+        final int stubIndex = mCommentBank.indexOf(parentStub);
+        if (stubIndex == -1) {
+            // Parent comment stub is no longer in the list, we've probably already processed this response
+            return;
+        }
+
         List<Listing> comments = response.getChildComments();
+
         if (comments == null || comments.size() == 0) {
             mCommentBank.remove(parentStub);
         } else {
             Timber.i("More comments: %d", comments.size());
+
             setDepthForCommentsList(comments, parentStub);
-            int stubIndex = mCommentBank.indexOf(parentStub);
+
             parentStub.removeChildren(comments);
             parentStub.setCount(parentStub.getChildren().size());
-            if (parentStub.getCount() == 0) mCommentBank.remove(stubIndex);
+
+            if (parentStub.getCount() == 0) {
+                mCommentBank.remove(stubIndex);
+            }
+
             mCommentBank.addAll(stubIndex, comments);
         }
+
         Integer minScore = mSettingsManager.getMinCommentScore();
         mCommentBank.collapseAllThreadsUnder(minScore);
+
         // TODO Specify commentRemoved and commentsAdded
         mLinkCommentsView.notifyDataSetChanged();
     }


### PR DESCRIPTION
I'm guessing if you double-tap a comment stub, we have the chance of processing two separate requests on the same list of comments, causing this condition. But in case I'm wrong about that, I've introduced a check that more directly ensures the crash won't happen again.