### PR TITLE
Sharing fixes for comments and links

### DIFF
--- a/app/src/main/java/com/ddiehl/android/htn/listings/BaseListingsFragment.kt
+++ b/app/src/main/java/com/ddiehl/android/htn/listings/BaseListingsFragment.kt
@@ -27,8 +27,8 @@ import rxreddit.model.PrivateMessage
 abstract class BaseListingsFragment : BaseFragment(), ListingsView, SwipeRefreshLayout.OnRefreshListener {
 
     companion object {
-        private val REQUEST_REPORT_LISTING = 1000
-        private val LINK_BASE_URL = "http://www.reddit.com"
+        private const val REQUEST_REPORT_LISTING = 1000
+        private const val LINK_BASE_URL = "http://www.reddit.com"
     }
 
     @BindView(R.id.recycler_view)

--- a/app/src/main/java/com/ddiehl/android/htn/listings/BaseListingsFragment.kt
+++ b/app/src/main/java/com/ddiehl/android/htn/listings/BaseListingsFragment.kt
@@ -28,7 +28,7 @@ abstract class BaseListingsFragment : BaseFragment(), ListingsView, SwipeRefresh
 
     companion object {
         private const val REQUEST_REPORT_LISTING = 1000
-        private const val LINK_BASE_URL = "http://www.reddit.com"
+        private const val LINK_BASE_URL = "https://www.reddit.com"
     }
 
     @BindView(R.id.recycler_view)

--- a/app/src/main/java/com/ddiehl/android/htn/listings/comments/LinkCommentsFragment.kt
+++ b/app/src/main/java/com/ddiehl/android/htn/listings/comments/LinkCommentsFragment.kt
@@ -94,7 +94,7 @@ class LinkCommentsFragment : BaseListingsFragment(), LinkCommentsView,
         val intent = Intent(Intent.ACTION_SEND).apply {
             action = Intent.ACTION_SEND
             type = "text/plain"
-            putExtra(Intent.EXTRA_TEXT, "http://www.reddit.com" + link.permalink)
+            putExtra(Intent.EXTRA_TEXT, "https://www.reddit.com" + link.permalink)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         startActivity(intent)
@@ -116,7 +116,7 @@ class LinkCommentsFragment : BaseListingsFragment(), LinkCommentsView,
     }
 
     override fun openCommentsInBrowser(link: Link) {
-        val uri = Uri.parse("http://www.reddit.com" + link.permalink)
+        val uri = Uri.parse("https://www.reddit.com" + link.permalink)
         val intent = Intent(Intent.ACTION_VIEW, uri)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         safeStartActivity(context, intent)

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         GLIDE_VERSION = '4.8.0'
         GLIDE_OKHTTP_VERSION = '4.8.0'
         BUTTERKNIFE_VERSION = '9.0.0-rc1'
-        RXREDDIT_VERSION = '0.11'
+        RXREDDIT_VERSION = '0.12'
         RXJAVA_VERSION = '2.2.1'
         RXANDROID_VERSION = '2.1.0'
         TIMESINCETEXTVIEW_VERSION = '1.3'


### PR DESCRIPTION
- Use HTTPS
- Fix format for comment shares, which redirects to full link handled by both browser and app